### PR TITLE
feat: distinguish circular references from max depth in replacer

### DIFF
--- a/JSON.prune.js
+++ b/JSON.prune.js
@@ -114,9 +114,10 @@
 				if (!value) {
 					return 'null';
 				}
-				if (depthDecr<=0 || seen.indexOf(value)!==-1) {
+				var isCircular = seen.indexOf(value)!==-1;
+				if (depthDecr<=0 || isCircular) {
 					if (replacer) {
-						var replacement = replacer(value, prunedString, true);
+						var replacement = replacer(value, prunedString, isCircular, isCircular ? 'circular' : 'depth');
 						return replacement===undefined ? undefined : ''+replacement;
 					}
 					return prunedString;

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ array with too many elements | Truncation: `JSON.prune` applied to only the star
 
 By specifiying a `replacer` or a `prunedString` in `JSON.prune` options, you can customize those prunings.
 
-The `replacer` function takes 3 arguments:
+The `replacer` function takes 4 arguments:
 * the value to replace
 * the default replacement value
-* a boolean indicating whether the replacement is due to a cycle detection
+* a boolean indicating whether the replacement is due to a cycle detection (`true` for circular, `false` otherwise)
+* a string indicating the reason for pruning: `'circular'` for circular references, `'depth'` for max depth reached, or `undefined` for other cases (e.g. `undefined` values, functions, array truncation)
 
 Returning `undefined` makes `JSON.prune` ommit the property (name and value).
 
@@ -90,13 +91,16 @@ Note: You get the same behavior with
 
 ### Example 3: Verbose Pruning
 
-	var options = {replacer:function(value, defaultValue, circular){
-		if (circular) return '"-circular-"';
+	var options = {replacer:function(value, defaultValue, circular, reason){
+		if (reason === 'circular') return '"-circular-"';
+		if (reason === 'depth') return '"-too-deep-"';
 		if (value === undefined) return '"-undefined-"';
 		if (Array.isArray(value)) return '"-array('+value.length+')-"';
 		return defaultValue;
 	}};
 	var json = JSON.prune(obj, options);
+
+Note: the `circular` boolean (third argument) is kept for backward compatibility. The `reason` string (fourth argument) provides more granular information: `'circular'` for circular references, `'depth'` for max depth reached.
 
 ### Example 4: Function "serialization"
 


### PR DESCRIPTION
## Summary

Fixes #14 - the `replacer` function now receives enough context to distinguish between circular references and max-depth pruning.

## Changes

### `JSON.prune.js`
Compute the circular flag before the combined condition, then pass it along with a reason string:
```js
// Before (both cases got circular=true)
if (depthDecr<=0 || seen.indexOf(value)!==-1) {
    if (replacer) {
        var replacement = replacer(value, prunedString, true);
        ...
    }
}

// After (circular flag and reason string are now correct)
var isCircular = seen.indexOf(value)!==-1;
if (depthDecr<=0 || isCircular) {
    if (replacer) {
        var replacement = replacer(value, prunedString, isCircular, isCircular ? 'circular' : 'depth');
        ...
    }
}
```

The replacer now receives **4 arguments**:
1. `value` - the value being pruned
2. `defaultValue` - the default replacement
3. `circular` - `true` for circular refs, `false` for depth (corrected from always `true`)
4. `reason` - `'circular'` or `'depth'` string (new)

### Backward compatibility
- The 4th argument is purely additive - existing 3-arg replacers continue to work
- The 3rd argument (`circular`) is now correct (`false` for depth, was incorrectly `true`)

### README
Updated documentation for the 4th replacer argument and updated Example 3.
